### PR TITLE
Revert "Update for Gerbil v0.18.1-92-g7c5753bd"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 build-deps
 *~
-db/_leveldb.c
-manifest.ss
-gambit.log

--- a/db/leveldb.ss
+++ b/db/leveldb.ss
@@ -283,7 +283,7 @@
         (leveldb-iter-fini state)
         (set! (iterator-e it) #f))))
 
-  (let (it (make-iterator e: state next: next fini: fini))
+  (let (it (make-iterator state next fini))
     (make-will it fini)
     (leveldb-iter-start state)
     it))


### PR DESCRIPTION
Reverts mighty-gerbils/gerbil-leveldb#2

The iterator constructor signature change is being reverted in Gerbil master, as it would deemed an unnecessary disruptive change.